### PR TITLE
Пример настройки разделенного режима сессий и правка ссылки

### DIFF
--- a/pages/framework/sessions.md
+++ b/pages/framework/sessions.md
@@ -41,7 +41,7 @@ var_dump($localStorage->get('productIds'));
 
 {% note info "" %}
 
-`SessionLocalStorage` работает на кеше, описанном в настройках файла `.settings.php`. Описание конфигурации смотрите ниже[.](#settings)
+`SessionLocalStorage` работает на кеше, описанном в настройках файла `.settings.php`. Описание конфигурации смотрите [ниже](#konfiguraciya-hraneniya-dannyh).
 
 {% endnote %}
 


### PR DESCRIPTION
1. В документации сейчас не однозначно описано добавление параметров настройки для разделенного режима. Написано добавить два параметра kernel и lifetime , но ведь их надо добавлять на разных уровнях. Потому сразу не получилось включить режим - пришлось искать и помогла старая документация где был наглядный пример.  Т.к. в тексте идет примечание, что примеры смотреть надо на странице настроек сессий добавил наглядный пример туда.
2.  На странице sessions.md была битая ссылка при этом ссылка была на точке, а не на слове - поправил