### PR TITLE
Исправил описание для config.php для renderExtension

### DIFF
--- a/pages/framework/controllers.md
+++ b/pages/framework/controllers.md
@@ -934,9 +934,7 @@ public function editorAction(string $blogCode): \Bitrix\Main\Engine\Response\Ren
 В `config.php` расширения укажите точку входа:
 
 ```php
-'render' => [
-    'controllerEntrypoint' => 'MyBlog.Vue.Editor.render',
-],
+'controllerEntrypoint' => 'MyBlog.Vue.Editor.render',
 ```
 
 {% note info "" %}


### PR DESCRIPTION
В `\Bitrix\Main\Engine\Response\Render\Extension::getControllerEntryPoint` указано что паарметр `controllerEntrypoint` берется не из `render` секции, а напрямую из конфигурации:

```php
	private function getControllerEntryPoint(): ?string
	{
		$config = \Bitrix\Main\UI\Extension::getConfig($this->extension);
		if (isset($config['controllerEntrypoint']))
		{
			if (!is_string($config['controllerEntrypoint']))
			{
				throw new InvalidConfigExtensionException(
					$this->extension,
					'`controllerEntrypoint` in config must be a string with JS function name',
				);
			}

			return $config['controllerEntrypoint'];
		}

		return null;
	}
```

Версия Битрикса: 25.1150.100